### PR TITLE
Update shell script for Implement Load Balancing on Compute Engine

### DIFF
--- a/Implement Load Balancing on Compute Engine Challenge Lab/gsp313.sh
+++ b/Implement Load Balancing on Compute Engine Challenge Lab/gsp313.sh
@@ -43,14 +43,12 @@ EOF
  
 gcloud compute instance-templates create web-server-template \
         --metadata-from-file startup-script=startup.sh \
-        --machine-type g1-small \
-        --region $REGION
+        --machine-type e2-medium \
  
 gcloud compute instance-groups managed create web-server-group \
         --base-instance-name web-server \
         --size 2 \
         --template web-server-template \
-        --region $REGION
  
 gcloud compute firewall-rules create $FIREWALL \
         --allow tcp:80 \
@@ -61,7 +59,6 @@ gcloud compute http-health-checks create http-basic-check
 gcloud compute instance-groups managed \
         set-named-ports web-server-group \
         --named-ports http:80 \
-        --region $REGION
  
 gcloud compute backend-services create web-server-backend \
         --protocol HTTP \
@@ -70,7 +67,6 @@ gcloud compute backend-services create web-server-backend \
  
 gcloud compute backend-services add-backend web-server-backend \
         --instance-group web-server-group \
-        --instance-group-region $REGION \
         --global
  
 gcloud compute url-maps create web-server-map \


### PR DESCRIPTION
Updating the shell script for "Implement Load Balancing on Compute Engine" challenge lab

- The machine type is `e2-medium` and the template needs to be global

*NOTE* : This should fix it but NEEDS TESTING.

Also, I ran into an issue of exhaustion:

<img width="1413" alt="Screenshot 2024-07-30 at 18 15 36" src="https://github.com/user-attachments/assets/a6248522-5468-4497-8216-abd8b5c9bb4c">

<img width="1413" alt="Screenshot 2024-07-30 at 18 15 23" src="https://github.com/user-attachments/assets/cd9bd330-662a-4dd6-9d6d-64801d36d927">

However, the script ran successfully:

<img width="1197" alt="Screenshot 2024-07-30 at 18 15 48" src="https://github.com/user-attachments/assets/ba77a0fc-ee74-4703-822d-31e34cda2875">
