### PR TITLE
Update gsp1036.sh to resolve VM creation failures

### DIFF
--- a/Securing Virtual Machines using BeyondCorp Enterprise BCE/gsp1036.sh
+++ b/Securing Virtual Machines using BeyondCorp Enterprise BCE/gsp1036.sh
@@ -34,7 +34,7 @@ gcloud compute instances create windows-iap \
     --zone=$ZONE \
     --machine-type=e2-medium \
     --network-interface=stack-type=IPV4_ONLY,subnet=default,no-address \
-    --create-disk=auto-delete=yes,boot=yes,device-name=windows-iap,image=projects/windows-cloud/global/images/windows-server-2016-dc-v20240313,mode=rw,size=20,type=projects/$DEVSHELL_PROJECT_ID/zones/$ZONE/diskTypes/pd-standard \
+    --create-disk=auto-delete=yes,boot=yes,device-name=windows-iap,image=projects/windows-cloud/global/images/windows-server-2016-dc-v20240313,mode=rw,size=50,type=projects/$DEVSHELL_PROJECT_ID/zones/$ZONE/diskTypes/pd-standard \
     --no-shielded-secure-boot \
     --shielded-vtpm \
     --shielded-integrity-monitoring \
@@ -50,7 +50,7 @@ gcloud compute instances create windows-connectivity \
     --maintenance-policy=MIGRATE \
     --provisioning-model=STANDARD \
     --scopes=https://www.googleapis.com/auth/cloud-platform \
-    --create-disk=auto-delete=yes,boot=yes,device-name=windows-connectivity,image=projects/qwiklabs-resources/global/images/iap-desktop-v001,mode=rw,size=20,type=projects/$DEVSHELL_PROJECT_ID/zones/$ZONE/diskTypes/pd-standard \
+    --create-disk=auto-delete=yes,boot=yes,device-name=windows-connectivity,image=projects/qwiklabs-resources/global/images/iap-desktop-v001,mode=rw,size=50,type=projects/$DEVSHELL_PROJECT_ID/zones/$ZONE/diskTypes/pd-standard \
     --no-shielded-secure-boot \
     --shielded-vtpm \
     --shielded-integrity-monitoring \


### PR DESCRIPTION
Update the default disk sizes for the Windows Server VM from 20GB to the new default size of 50GB.

This modification will resolve the failing VM creation tasks

![image](https://github.com/user-attachments/assets/e244c07b-498a-4265-adef-d01ce7514a46)

- [ ] gcloud compute instances create windows-iap
- [ ] gcloud compute instances create windows-connectivity

![image](https://github.com/user-attachments/assets/78f92050-453c-42c7-9fa5-80c727e92305)

