### PR TITLE
The Following Command Should be done in Linux-instance

### DIFF
--- a/Google Cloud Speech-to-Text API Qwik Start/Google Cloud Speech-to-Text API Qwik Start.md
+++ b/Google Cloud Speech-to-Text API Qwik Start/Google Cloud Speech-to-Text API Qwik Start.md
@@ -2,24 +2,24 @@
 
 ## Solution [here](https://youtu.be/bx-D7ypXnWM)
 
-### Run the following Commands in SSH
+### Step 1: Connect to the Linux instance
+1. Navigate to **Compute Engine** in the Google Cloud Console menu
+2. Find the **linux-instance** in the VM instances list
+3. Click on the **SSH** button next to the linux-instance VM
+4. Wait for the SSH connection to establish in a new window
+
+### Step 2: Run the following Commands in SSH
 ```
 export API_KEY=
 ```
 ```
 curl -LO raw.githubusercontent.com/QUICK-GCP-LAB/2-Minutes-Labs-Solutions/main/Google%20Cloud%20Speech-to-Text%20API%20Qwik%20Start/gsp119.sh
-
 sudo chmod +x gsp119.sh
-
 ./gsp119.sh
 ```
 
 ### Congratulations 🎉 for completing the Lab !
-
 ##### *You Have Successfully Demonstrated Your Skills And Determination.*
-
-#### *Well done!*
-
+#### *Well done!*
 #### Don't Forget to Join the [Telegram Channel](https://t.me/quickgcplab) & [Discussion group](https://t.me/quickgcplabchats)
-
 # [QUICK GCP LAB](https://www.youtube.com/@quickgcplab)


### PR DESCRIPTION
Added Step 1 for connecting to Linux instance VM

This commit adds explicit instructions for connecting to the Linux instance VM before running the lab commands. Many users were skipping this crucial step, causing confusion when commands didn't work in the Cloud Shell.

Changes:
- Added "Step 1: Connect to the Linux instance" with clear navigation instructions
- Included 4 detailed sub-steps to guide users through the SSH connection process
- Reformatted the existing commands as "Step 2" for better flow
- Maintained all original command content and formatting

This addition should help reduce user confusion and improve lab completion rates.