### PR TITLE
[GSP021] Fix setting of project id

### DIFF
--- a/Orchestrating the Cloud with Kubernetes/Orchestrating the Cloud with Kubernetes.md
+++ b/Orchestrating the Cloud with Kubernetes/Orchestrating the Cloud with Kubernetes.md
@@ -4,6 +4,7 @@
 
 ### Run the following Commands in CloudShell
 ```
+export PROJECT_ID=
 export ZONE=
 ```
 ```

--- a/Orchestrating the Cloud with Kubernetes/gsp021.sh
+++ b/Orchestrating the Cloud with Kubernetes/gsp021.sh
@@ -22,9 +22,11 @@ RESET=`tput sgr0`
 
 echo "${YELLOW}${BOLD}Starting${RESET}" "${GREEN}${BOLD}Execution${RESET}"
 
+gcloud config set project $PROJECT_ID
+
 gcloud config set compute/zone $ZONE
 
-gcloud container clusters create io
+gcloud container clusters create io --zone $ZONE
 
 gsutil cp -r gs://spls/gsp021/* .
 


### PR DESCRIPTION
## ❓ Why is it being changed

The current version of the script does not cover setting of project id on google cloud shell. By my experience of the current skills boost lab, the project id is not configured by default when i start the lab.

## 🤔 What was changed

- Configuring the `PROJECT_ID` env variable on the cloud shell is added.
- Command to set the project id of the cloud shell into the value of the project-id env variable is added.
- Fixed: Provisioning of GKE cluster on target zone.