### PR TITLE
feat(arc104.sh): Fix variable usage for function directory creation

### DIFF
--- a/Cloud Functions 3 Ways Challenge Lab/arc104.sh
+++ b/Cloud Functions 3 Ways Challenge Lab/arc104.sh
@@ -100,7 +100,7 @@ done
 
 cd ..
 
-mkdir ~/HTTP_FUNCTION && cd $_
+mkdir ~/$HTTP_FUNCTION && cd $_
 touch index.js && touch package.json
 
 cat > index.js <<EOF


### PR DESCRIPTION
Replaced hardcoded string `FUNCTION_NAME` with variable `$FUNCTION_NAME` to correctly create and navigate into the intended function directory. This ensures the folder is named according to the value of the environment variable, avoiding unexpected behavior during deployment.

Changes:

* Updated `mkdir ~/FUNCTION_NAME` to `mkdir ~/$FUNCTION_NAME`
* Ensured consistency with `cd $_` to navigate into the newly created directory